### PR TITLE
Fixed typographical error, changed aplication to application in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ itself relaunched into a new session, while allowing it to pass on arbitrary
 application state to the new instance. This includes inheritance of open
 file descriptors.
 
-Any aplication wanting to hook into this service, must import this package,
+Any application wanting to hook into this service, must import this package,
 and implement the API it exposes. An example of this can be seen in
 `testdata/main.go`.
 


### PR DESCRIPTION
@jteeuwen, I've corrected a typographical error in the documentation of the [mitosis](https://github.com/jteeuwen/mitosis) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.